### PR TITLE
Add pruning support to pkvstore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -326,13 +326,13 @@ build_c-amazonlinux:
 
 # Run a 4-node testnet locally
 localnet-start: localnet-stop build-docker-localnode
-	@if ! [ -f build/node0/config/genesis.json ]; then docker run --rm -v $(CURDIR)/build:/cometbft:Z cometbft/localnode testnet --config /etc/cometbft/config-template.toml --o . --starting-ip-address 192.167.10.2; fi
-	docker-compose up
+	@if ! [ -f build/node0/config/genesis.json ]; then docker run --rm -v $(CURDIR)/build:/cometbft:Z cometbft/localnode testnet --config /etc/cometbft/config-template.toml --o . --starting-ip-address 192.167.0.2; fi
+	docker compose up
 .PHONY: localnet-start
 
 # Stop testnet
 localnet-stop:
-	docker-compose down
+	docker compose down
 .PHONY: localnet-stop
 
 # Build hooks for dredd, to skip or add information on some steps

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - ./build:/cometbft:Z
     networks:
       localnet:
-        ipv4_address: 192.167.10.2
+        ipv4_address: 192.167.0.2
 
   node1:
     container_name: node1
@@ -27,7 +27,7 @@ services:
       - ./build:/cometbft:Z
     networks:
       localnet:
-        ipv4_address: 192.167.10.3
+        ipv4_address: 192.167.0.3
 
   node2:
     container_name: node2
@@ -41,7 +41,7 @@ services:
       - ./build:/cometbft:Z
     networks:
       localnet:
-        ipv4_address: 192.167.10.4
+        ipv4_address: 192.167.0.4
 
   node3:
     container_name: node3
@@ -55,7 +55,7 @@ services:
       - ./build:/cometbft:Z
     networks:
       localnet:
-        ipv4_address: 192.167.10.5
+        ipv4_address: 192.167.0.5
 
 networks:
   localnet:
@@ -63,4 +63,4 @@ networks:
     ipam:
       driver: default
       config:
-        - subnet: 192.167.10.0/16
+        - subnet: 192.167.0.0/16

--- a/networks/local/localnode/Dockerfile
+++ b/networks/local/localnode/Dockerfile
@@ -8,7 +8,7 @@ VOLUME /cometbft
 WORKDIR /cometbft
 EXPOSE 26656 26657
 ENTRYPOINT ["/usr/bin/wrapper.sh"]
-CMD ["node", "--proxy_app", "kvstore"]
+CMD ["node", "--proxy_app", "persistent_kvstore"]
 STOPSIGNAL SIGTERM
 
 COPY wrapper.sh /usr/bin/wrapper.sh

--- a/networks/local/localnode/config-template.toml
+++ b/networks/local/localnode/config-template.toml
@@ -1,2 +1,5 @@
+# Output level for logging, including package level options
+log_level = "debug"
+
 [rpc]
 laddr = "tcp://0.0.0.0:26657"


### PR DESCRIPTION
Useful to experiment with pruning.

With:

```
make build
make localnet-start
```

Then in a new terminal stopping a node with:

```
docker compose down node0
```

Then pruning at a height after the node has been stopped, with:

```
curl -vs 'localhost:26660/broadcast_tx_commit?tx="retain:<height>"'
```

Then restarting the node with:

```
docker compose up node0
```

`node0` gets stuck. This doesn't happen without pruning or when pruning _before_ stopping and restarting `node0`.